### PR TITLE
Changed 'telegram' to 'telegram-desktop' on Debian & Ubuntu

### DIFF
--- a/appssetup.sh
+++ b/appssetup.sh
@@ -70,7 +70,7 @@ do
                     if [[ "$distro" = "ubuntu" ]]; then
                         addRepo "Universe" "Telegram"
                     fi
-                    sudo apt-get install telegram
+                    sudo apt-get install telegram-desktop
                 ;;
                 #'Lexmark Printer Driver')
                     # .deb package in preparation...


### PR DESCRIPTION
Changed package name of `telegram` to `telegram-desktop` on Debian and Ubuntu.
On this distros script not worked for this package. 